### PR TITLE
Support Django 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 bin
 include
 lib
+local
 dist
 django_licensing.egg-info
-
+*pyc
+*swp

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@ The characters in the ``symbols`` fields of the provided Creative Commons
 licenses are intended to be displayed with this Creative Commons icons font:
 http://pfefferle.github.io/openwebicons/#cc-icons
 
+Supported Django versions
+-------------------------
+Licensing is tested against Django versions 1.8 and 1.9.
+
 Quick start
 -----------
 

--- a/licensing/migrations/0001_initial.py
+++ b/licensing/migrations/0001_initial.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             name='License',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.CharField(unique=True, max_length=b'80')),
+                ('name', models.CharField(unique=True, max_length=80)),
                 ('symbols', models.CharField(max_length=5)),
                 ('url', models.URLField(unique=True)),
             ],

--- a/licensing/migrations/0001_initial.py
+++ b/licensing/migrations/0001_initial.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='License',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(unique=True, max_length=b'80')),
+                ('symbols', models.CharField(max_length=5)),
+                ('url', models.URLField(unique=True)),
+            ],
+        ),
+    ]

--- a/licensing/migrations/0002_load_licenses.py
+++ b/licensing/migrations/0002_load_licenses.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.core.management import call_command
+
+
+def load_license_fixture(apps, schema_editor):
+    call_command('loaddata', 'initial_data.json', app_label='licensing')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('licensing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_license_fixture)
+    ]

--- a/licensing/models.py
+++ b/licensing/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 
 class License(models.Model):
-    name = models.CharField(max_length='80', unique=True)
+    name = models.CharField(max_length=80, unique=True)
     symbols = models.CharField(max_length=5)
     url = models.URLField(unique=True)
 

--- a/licensing/test_settings.py
+++ b/licensing/test_settings.py
@@ -1,0 +1,18 @@
+DEBUG=True
+
+DATABASES={
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+    }
+}
+
+SECRET_KEY = 'secret'
+
+INSTALLED_APPS=(
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.admin',
+    'licensing',
+    'tests',
+)

--- a/runtests.py
+++ b/runtests.py
@@ -1,26 +1,16 @@
 #!/usr/bin/env python
 
-# original code from <http://stackoverflow.com/questions/3841725/>
-
 import os
 import sys
+
 import django
+from django.test.runner import DiscoverRunner
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'licensing.test_settings'
 
-try:
-    # Django <= 1.8
-    from django.test.simple import DjangoTestSuiteRunner
-    test_runner = DjangoTestSuiteRunner(verbosity=1)
-except ImportError:
-    # Django >= 1.8
-    from django.test.runner import DiscoverRunner
-    test_runner = DiscoverRunner(verbosity=1)
-
-# otherwise we get an 'Apps not loaded yet' error
-if hasattr(django, 'setup'):
-    django.setup()
-
+django.setup()
+test_runner = DiscoverRunner(verbosity=1)
 failures = test_runner.run_tests(['tests'])
+
 if failures:
     sys.exit(failures)

--- a/runtests.py
+++ b/runtests.py
@@ -1,23 +1,12 @@
 #!/usr/bin/env python
-# original code from <http://stackoverflow.com/questions/3841725/how-to-launch-tests-for-django-reusable-app>
-import os, sys
-from django.conf import settings
+
+# original code from <http://stackoverflow.com/questions/3841725/>
+
+import os
+import sys
 import django
 
-
-settings.configure(DEBUG=True,
-               DATABASES={
-                    'default': {
-                        'ENGINE': 'django.db.backends.sqlite3',
-                    }
-                },
-               #ROOT_URLCONF='myapp.urls',
-               INSTALLED_APPS=('django.contrib.auth',
-                              'django.contrib.contenttypes',
-                              'django.contrib.sessions',
-                              'django.contrib.admin',
-                              'licensing',
-                              'tests',))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'licensing.test_settings'
 
 try:
     # Django <= 1.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 # http://martinbrochhaus.com/tox.html
 [tox]
-envlist = py27-django{17,18}
+envlist = py27-django{17,18,19}
 [testenv]
 usedevelop = True
 deps =
     django17: Django==1.7
     django18: Django==1.8
+    django19: Django==1.9
 commands=./runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 # http://martinbrochhaus.com/tox.html
 [tox]
-envlist = py27-django{17,18,19}
+envlist = py27-django{18,19}
 [testenv]
 usedevelop = True
 deps =
-    django17: Django==1.7
     django18: Django==1.8
     django19: Django==1.9
 commands=./runtests.py


### PR DESCRIPTION
`initial_data.json` is no longer loaded by default. This adds a data migration to load it instead.

@rybesh, I can't figure out how to make the Django 1.7 test runner to run the migrations on load (the 1.8+ runner does it automatically). According to <https://www.djangoproject.com/download/>, 1.7 isn't officially supported anymore. Should we remove it, or futz around with the test settings until it works?