### PR TITLE
Add __str__() method to license model

### DIFF
--- a/licensing/models.py
+++ b/licensing/models.py
@@ -9,6 +9,9 @@ class License(models.Model):
     def __unicode__(self):
         return self.name
 
+    def __str__(self):
+        return self.name
+
     def get_absolute_url(self):
         return self.url
 


### PR DESCRIPTION
__unicode__() is not used in python3